### PR TITLE
Add arrays to config file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ objects."are awesome." yes
 objects."also have brackets".{
     totally my dude
 }
+objects.can_also_contain_arrays.[
+    totally
+    my dude
+]
 `);
 
 console.log(util.inspect(config));
@@ -41,7 +45,11 @@ Output:
         'are awesome.': true,
         'also have brackets': {
             'totally': "my dude"
-        }
+        },
+        'can_also_contain_arrays': [
+            "totally"
+            "my dude"
+        ]
     }
 }
 ```
@@ -53,7 +61,10 @@ Output:
 [node-version-url]: https://nodejs.org/en/download/
 
 [build-status-image]: https://travis-ci.org/ARitz-Cracker/arc-config.svg
-[build-status-url]: https://travis-ci.org/ARitz-Cracker/arc-config
+[bu{
+	abcd yes
+	1234 yes
+}ild-status-url]: https://travis-ci.org/ARitz-Cracker/arc-config
 
 [license-image]: https://img.shields.io/npm/l/arc-config.svg?maxAge=2592000
 [license-url]: LICENSE

--- a/index.js
+++ b/index.js
@@ -80,6 +80,22 @@ exports.Decode = function(str = ""){
 						state = STATE_VALUE;
 						break;
 					case ".":{
+						if(str[i + 1] === "["){
+							const i2 = str.indexOf("]", i + 1);
+							const lines = str.substring(i + 2, i2).split("\n");
+							const value = [];
+							for(let ii = 0; ii < lines.length; ii += 1){
+								let[val] = lines[ii].split("#", 1);
+								val = val.trim();
+								if(val){
+									value.push(guessValType(val));
+								}
+							}
+							curObject[curKey] = value;
+							curKey = "";
+							i = i2;
+							break;
+						}
 						const newObject = curObject[curKey];
 						if(newObject == null){
 							curObject[curKey] = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arc-config",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Some config file format I made.",
 	"main": "index.js",
 	"scripts": {

--- a/test/decoding.js
+++ b/test/decoding.js
@@ -234,4 +234,38 @@ describe("aritz.conf decoder", function() {
 			}
 		});
 	});
+	it("has arrays", function() {
+		expect(
+			decode(
+				"aaaa.[\n" +
+				"hello\n" +
+				"world\n" +
+				"yes\n" +
+				"]"
+			)
+		).to.deep.equal({
+			aaaa: [
+				"hello",
+				"world",
+				true
+			]
+		});
+	});
+	it("handles comments in arrays", function() {
+		expect(
+			decode(
+				"aaaa.[#aaaa\n" +
+				"hello#bbb\n" +
+				"world#ccc\n" +
+				"yes#dd\n" +
+				"]"
+			)
+		).to.deep.equal({
+			aaaa: [
+				"hello",
+				"world",
+				true
+			]
+		});
+	});
 });


### PR DESCRIPTION
This adds array support to the config file format. Useful for having lists of items.

The following file:
```
my_list.[
    onething
    twothing
    threething
]
```

will produce the following JS object
```js
{
    my_list: [
        "onething",
        "twothing",
        "threething"
    ]
}
```

Unit tests have also been added for this new feature